### PR TITLE
fix(bootstrap,meterial) Allow Select Type, Value to be a object (#910)

### DIFF
--- a/src/ui-bootstrap/src/types/select.spec.ts
+++ b/src/ui-bootstrap/src/types/select.spec.ts
@@ -44,6 +44,7 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
                 options: [
                     { id: '1', name: 'Soccer' },
                     { id: '2', name: 'Basketball' },
+                    { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
                 ],
                 valueProp: 'id',
                 labelProp: 'name',
@@ -52,13 +53,14 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
 
         const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+        expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     });
 
     it('should correctly bind to an Observable', async(() => {
       const sports$ = of([
         { id: '1', name: 'Soccer' },
         { id: '2', name: 'Basketball' },
+        { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
       ]);
 
       testComponentInputs.fields = [{
@@ -73,7 +75,7 @@ describe('ui-bootstrap: Formly Field Select Component', () => {
 
       const fixture = createTestComponent('<formly-form [form]="form" [fields]="fields" [model]="model" [options]="options"></formly-form>');
 
-      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(2);
+      expect(fixture.debugElement.query(By.css('select')).nativeElement.options.length).toEqual(3);
     }));
 
   });

--- a/src/ui-bootstrap/src/types/select.ts
+++ b/src/ui-bootstrap/src/types/select.ts
@@ -5,12 +5,12 @@ import { of } from 'rxjs/observable/of';
 
 export class SelectOption {
   label: string;
-  value?: string;
+  value?: any;
   group?: SelectOption[];
   disabled?: boolean;
   [key: string]: any;
 
-  constructor(label: string, value?: string, children?: SelectOption[]) {
+  constructor(label: string, value?: any, children?: SelectOption[]) {
     this.label = label;
     this.value = value;
     this.group = children;

--- a/src/ui-material/src/types/select.spec.ts
+++ b/src/ui-material/src/types/select.spec.ts
@@ -53,6 +53,7 @@ describe('ui-material: Formly Field Select Component', () => {
           options: [
             { id: '1', name: 'Soccer' },
             { id: '2', name: 'Basketball' },
+            { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
           ],
           valueProp: 'id',
           labelProp: 'name',
@@ -65,13 +66,14 @@ describe('ui-material: Formly Field Select Component', () => {
       trigger.click();
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(3);
     });
 
     it('should correctly bind to an Observable', async(() => {
       const sports$ = of([
         { id: '1', name: 'Soccer' },
         { id: '2', name: 'Basketball' },
+        { id: {test: 'A'}, name: 'Not Soccer or Basketball' },
       ]);
 
       testComponentInputs.fields = [{
@@ -90,7 +92,7 @@ describe('ui-material: Formly Field Select Component', () => {
       trigger.click();
       fixture.detectChanges();
 
-      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(2);
+      expect(fixture.debugElement.queryAll(By.css('mat-option')).length).toEqual(3);
     }));
 
   });

--- a/src/ui-material/src/types/select.ts
+++ b/src/ui-material/src/types/select.ts
@@ -6,12 +6,12 @@ import { Observable } from 'rxjs/Observable';
 
 export class SelectOption {
   label: string;
-  value?: string;
+  value?: any;
   group?: SelectOption[];
   disabled?: boolean;
   [key: string]: any;
 
-  constructor(label: string, value?: string, children?: SelectOption[]) {
+  constructor(label: string, value?: any, children?: SelectOption[]) {
     this.label = label;
     this.value = value;
     this.group = children;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)


**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
